### PR TITLE
Crash when SOLR is not available

### DIFF
--- a/lib/solr.js
+++ b/lib/solr.js
@@ -1,5 +1,7 @@
 var http = require("http");
 var querystring = require("querystring");
+var util = require('util');
+var EventEmitter = require('events').EventEmitter;
 
 // callback || noop borrowed from node/lib/fs.js
 function noop() {};
@@ -11,6 +13,8 @@ var Client = function(host, port, core, path) {
   this.core = core || ""; // if defined, should begin with a slash
   this.path = path || "/solr"; // should also begin with a slash
 };
+
+util.inherits(Client,EventEmitter);
 
 Client.prototype.add = function(doc, options, callback) {
   if (callback === undefined) {
@@ -177,7 +181,9 @@ exports.createClient = function(host, port, core, path) {
       });
     });
     request.on('error', function (e) {
-      throw new Error('Unable to connect to Solr ('+e.message+')');
+      //throw new Error('Unable to connect to Solr ('+e.message+')');
+	    client.emit('error',e);
+	    callback(e);
     });
     if (options.data) {
       request.write(options.data, options.requestEncoding || 'utf8');


### PR DESCRIPTION
When SOLR is not available, the whole app will crash.
Instead we want to notify the client with our custom 500 Internal Server Error.
Instead of throwing errors when SOLR is not reachable, node-solr should probably emit an error event and call callback with error info.
