### PR TITLE
Support for multiple faceting fields

### DIFF
--- a/lib/solr.js
+++ b/lib/solr.js
@@ -93,7 +93,27 @@ Client.prototype.query = function(query, options, callback) {
   var queryParams = options || {};
   queryParams.q = query;
   queryParams.wt = "json";
+
+  var facets;
+  if('facets' in queryParams) {
+    facets = queryParams.facets;
+    delete queryParams['facets'];
+    queryParams.facet = true;
+  }
+
   queryParams = querystring.stringify(queryParams, '&', '=', false);
+
+  if(facets) {
+    for(var field in facets) {
+      var opts = facets[field];
+      var fopts = {};
+      for(var o in opts) {
+        fopts['f.'+field+'.facet.'+o] = opts[o];
+      }
+      queryParams += '&facet.field=' + field + '&' + querystring.stringify(fopts, '&', '=', false);
+    }
+  }
+
   this.rawQuery(queryParams, callback);
 };
 


### PR DESCRIPTION
We ran into the problem: we couldn't add multiple faceting fields to the query with node-solr.
So we added this fix.

Usage:
    var params = {
        fl : '...',
        facets : {
            field1 : {
                method:'fc',
                sort:'count'
            },
            field2 : {
                method:'enum' 
            }
        }
    };

```
solr.query('*:*', params, function(err, response) { });
```
