### PR TITLE
Added HTTP status to returned error.

### DIFF
--- a/lib/solr.js
+++ b/lib/solr.js
@@ -13,7 +13,7 @@ var DEFAULTS = {
 function Client(options) {
   options = options || {};
   this.options = merge(options, DEFAULTS);
-};
+}
 
 exports.Client = Client;
 
@@ -33,6 +33,7 @@ Client.prototype.request = function(options, callback) {
     response.on('end', function() {
       if (response.statusCode !== 200) {
         var err = new Error(exports.getError(buffer));
+        err.headers = { status: response.statusCode };
         callback(err);
       } else {
         callback(null, buffer);
@@ -180,7 +181,7 @@ exports.valueEscape = function(query) {
   return query.replace(/\\?([&|+\-!(){}[\]^"~*?\:]{1})/g, function(str, c) {
     return '\\' + c;
   });
-}
+};
 
 // main export function
 exports.createClient = function(options) {
@@ -192,7 +193,7 @@ exports.createClient = function(options) {
 // Helper functions
 
 // callback || noop borrowed from node/lib/fs.js
-function noop() {};
+function noop() {}
 
 function escapeXml(str) {
   return str.replace(/&/gm, '&amp;')
@@ -200,7 +201,7 @@ function escapeXml(str) {
             .replace(/>/gm, '&gt;')
             .replace(/\'/gm, '&apos;')
             .replace(/\"/gm, '&quot;');
-};
+}
 
 function merge(a, b){
   if (a && b) {
@@ -213,12 +214,12 @@ function merge(a, b){
     }
   }
   return a;
-};
+}
 
 function serializeScalar(field, value) {
   value = '' + value;
   return '<field name = "' + field + '">' + escapeXml(value) + '</field>';
-};
+}
 
 function serializeList(field, list) {
   var data = '';
@@ -228,4 +229,4 @@ function serializeList(field, list) {
     }
   });
   return data;
-};
+}


### PR DESCRIPTION
When an error is returned from a SOLR request, the HTTP status information is lost. The HTTP status code is a better way of determining the reason for request failure than string matching on the error string. This is required when using the get() method when special handling may be required for a 404.
