### PR TITLE
Optional parameters for updating documents

### DIFF
--- a/README
+++ b/README
@@ -55,3 +55,20 @@ See tests for usage. Here's a quick example:
         });
       });
     });
+
+## Optional Parameters for Add documents
+
+Solr add/replace documents supports optional parameters.
+
+```
+var doc1 = {
+  id: '1',
+  title_t: {
+    params: {
+      boost: '2.0'
+    },
+    value: 'Foo bar',
+  },
+  text_t: 'Fizz buzz frizzle'
+};
+```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,71 @@
+# Solr module for Node.js
+
+## References
+* Node.js: http://github.com/joyent/node
+* Solr: http://lucene.apache.org/solr/
+
+Run tests with `npm test`. Edit "test/common.js" if you don't have Solr running at 127.0.0.1:8983. 
+
+## Usage Example
+
+See tests for usage. Here's a quick example:
+
+```javascript
+    var solr = require('solr');
+
+    var client = solr.createClient();
+    var doc1 = {
+      id: '1',
+      title_t: 'Foo bar',
+      text_t: 'Fizz buzz frizzle'
+    };
+    var doc2 = {
+      id: '2',
+      title_t: 'Far boo',
+      text_t: 'Wuzz fizz drizzle'
+    };
+
+    client.add(doc1, function(err) {
+      if (err) throw err;
+      console.log('First document added');
+      client.add(doc2, function(err) {
+        if (err) throw err;
+        console.log('Second document added');
+        client.commit(function(err) {
+          var query = 'text_t:fizz'
+          client.query(query, function(err, response) {
+            if (err) throw err;
+            var responseObj = JSON.parse(response);
+            console.log('A search for "' + query + '" returned ' +
+                responseObj.response.numFound + ' documents.');
+            console.log('First doc title: ' + 
+                responseObj.response.docs[0].title_t);
+            console.log('Second doc title: ' + 
+                responseObj.response.docs[1].title_t);
+            client.del(null, query, function(err, response) {
+              if (err) throw err;
+              console.log('Deleted all docs matching query "' + query + '"');
+              client.commit()
+            });
+          });
+        });
+      });
+    });
+```
+
+## Optional Parameters for Add documents
+
+Solr add/replace documents supports optional parameters.
+
+```javascript
+var doc1 = {
+  id: '1',
+  title_t: {
+    params: {
+      boost: '2.0'
+    },
+    value: 'Foo bar',
+  },
+  text_t: 'Fizz buzz frizzle'
+};
+```

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ See tests for usage. Here's a quick example:
     });
 ```
 
-## Optional Parameters for Add documents
+## Optional Parameters
 
 Solr add/replace documents supports optional parameters.
 

--- a/lib/solr.js
+++ b/lib/solr.js
@@ -98,10 +98,22 @@ Client.prototype.add = function(doc, options, callback) {
     var doc = docs[i];
     for (var field in doc) if (doc.hasOwnProperty(field)) {
       var value = doc[field];
-      if (!Array.isArray(value)) {
-        data += serializeScalar(field, value);
-      } else {
-        data += serializeList(field, value);
+      var params = null;
+      switch(true) {
+        case (!Array.isArray(value) && typeof value !== "object") :
+          data += serializeScalar(field, value);
+          break;
+        case (!Array.isArray(value) && typeof value === "object") :
+          // "value" should have "{params:{k:v,..},value:xx}"
+          params = value.params;
+          if (Array.isArray(value.value)) {
+            data += serializeList(field, value, params);
+          } else {
+            data += serializeScalar(field, value, params);
+          }
+          break;
+        default :
+          data += serializeList(field, value);
       }
     }
     data += "</doc>";
@@ -216,16 +228,40 @@ function merge(a, b){
   return a;
 }
 
-function serializeScalar(field, value) {
+/**
+ * Convert the field, value and params into an XML entity
+ * @param  {string} field  Name of the field
+ * @param  {string} value  Field value
+ * @param  {Object} params Optional set of paramaters, key/value set
+ * @return {string}        String with the field to be added to the XML document
+ */
+function serializeScalar(field, value, params) {
+  var fieldParams = "";
+  params = (params typeof params !== 'undefined') ? params : "";
+
+  if (params typeof "object") {
+    for (var key in params) {
+      if (params.hasOwnProperty(key)) {
+        fieldParams .= ' ' + key + '="' + params[key] + '"'
+      }
+    }
+  }
   value = '' + value;
-  return '<field name = "' + field + '">' + escapeXml(value) + '</field>';
+  return '<field name= "' + field + '"' + fieldParams + '>' + escapeXml(value) + '</field>';
 }
 
-function serializeList(field, list) {
+/**
+ * Convert a list of values into a string to be added to the XML main document
+ * @param  {string} field Field name
+ * @param  {Array} list   List or sub-values
+ * @param  {Object} params Optional set of paramaters, key/value set
+ * @return {string}       XML elements to be added to the main XML document
+ */
+function serializeList(field, list, params) {
   var data = '';
   list.forEach(function(value) {
     if (!Array.isArray(value)) {
-      data += serializeScalar(field, value);
+      data += serializeScalar(field, value, params);
     }
   });
   return data;

--- a/lib/solr.js
+++ b/lib/solr.js
@@ -100,17 +100,19 @@ Client.prototype.add = function(doc, options, callback) {
       var value = doc[field];
       var params = null;
       switch(true) {
-        case (!Array.isArray(value) && typeof value !== "object") :
+        case (value && !Array.isArray(value) && typeof value !== "object") :
           data += serializeScalar(field, value);
           break;
-        case (!Array.isArray(value) && typeof value === "object") :
-          // "value" should have "{params:{k:v,..},value:xx}"
+        case (value && !Array.isArray(value) && typeof value === "object") :
           params = value.params;
           if (Array.isArray(value.value)) {
             data += serializeList(field, value.value, params);
           } else {
             data += serializeScalar(field, value.value, params);
           }
+          break;
+        case (!value && typeof value === "object") :
+          data += serializeScalar(field, value);
           break;
         default :
           data += serializeList(field, value);
@@ -238,7 +240,7 @@ function merge(a, b){
 function serializeScalar(field, value, params) {
   var fieldParams = "";
   params = (typeof params !== 'undefined') ? params : "";
-  if (typeof params === "object") {
+  if (params && typeof params === "object") {
     for (var key in params) {
       if (params.hasOwnProperty(key)) {
         fieldParams += ' ' + key + '="' + params[key] + '"';
@@ -259,6 +261,10 @@ function serializeScalar(field, value, params) {
  */
 function serializeList(field, list, params) {
   var data = '';
+  if (!Array.isArray(list)) {
+    return data;  
+  }
+
   list.forEach(function(value) {
     if (!Array.isArray(value)) {
       data += serializeScalar(field, value, params);

--- a/lib/solr.js
+++ b/lib/solr.js
@@ -107,9 +107,9 @@ Client.prototype.add = function(doc, options, callback) {
           // "value" should have "{params:{k:v,..},value:xx}"
           params = value.params;
           if (Array.isArray(value.value)) {
-            data += serializeList(field, value, params);
+            data += serializeList(field, value.value, params);
           } else {
-            data += serializeScalar(field, value, params);
+            data += serializeScalar(field, value.value, params);
           }
           break;
         default :
@@ -238,16 +238,16 @@ function merge(a, b){
 function serializeScalar(field, value, params) {
   var fieldParams = "";
   params = (typeof params !== 'undefined') ? params : "";
-
   if (typeof params === "object") {
     for (var key in params) {
       if (params.hasOwnProperty(key)) {
-        fieldParams += ' ' + key + '="' + params[key] + '"'
+        fieldParams += ' ' + key + '="' + params[key] + '"';
       }
     }
   }
+
   value = '' + value;
-  return '<field name= "' + field + '"' + fieldParams + '>' + escapeXml(value) + '</field>';
+  return '<field name="' + field + '"' + fieldParams + '>' + escapeXml(value) + '</field>';
 }
 
 /**

--- a/lib/solr.js
+++ b/lib/solr.js
@@ -237,7 +237,7 @@ function merge(a, b){
  */
 function serializeScalar(field, value, params) {
   var fieldParams = "";
-  params = (params typeof params !== 'undefined') ? params : "";
+  params = (typeof params !== 'undefined') ? params : "";
 
   if (params typeof "object") {
     for (var key in params) {

--- a/lib/solr.js
+++ b/lib/solr.js
@@ -242,7 +242,7 @@ function serializeScalar(field, value, params) {
   if (typeof params === "object") {
     for (var key in params) {
       if (params.hasOwnProperty(key)) {
-        fieldParams .= ' ' + key + '="' + params[key] + '"'
+        fieldParams += ' ' + key + '="' + params[key] + '"'
       }
     }
   }

--- a/lib/solr.js
+++ b/lib/solr.js
@@ -239,7 +239,7 @@ function serializeScalar(field, value, params) {
   var fieldParams = "";
   params = (typeof params !== 'undefined') ? params : "";
 
-  if (params typeof "object") {
+  if (typeof params === "object") {
     for (var key in params) {
       if (params.hasOwnProperty(key)) {
         fieldParams .= ' ' + key + '="' + params[key] + '"'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 { "name" : "solr"
 , "description" : "A low-level Solr client"
-, "version" : "0.2.2"
+, "version" : "0.3.0"
 , "author" : "Gabriel Farrell <gsf747@gmail.com>"
 , "contributors" :
   [ "Sergey Polzunov <sergey@polzunov.com>"
@@ -12,12 +12,13 @@
   , "V Sreekanth <sreeix@gmail.com>"
   , "Ryan <ryan.fairchild@gmail.com>"
   , "Fyodor Y <fygrave@o0o.nu>"
+  , "Pablo Viquez <pviquez@pabloviquez.com>"
   ]
 , "engines" : { "node": ">=0.4.0" }
 , "main" : "lib/solr"
 , "repository" :
   { "type" : "git"
-  , "url" : "http://github.com/gsf/node-solr.git"
+  , "url" : "https://github.com/pabloviquez/node-solr.git"
   }
 , "scripts" : { "test" : "find test/test-*.js | xargs -n 1 -t node" }
 }

--- a/test/test-update-params.js
+++ b/test/test-update-params.js
@@ -1,0 +1,38 @@
+var common = require('./common');
+var assert = common.assert;
+var client = common.createClient();
+var solr = common.solr;
+
+common.expected = 1;
+
+client.del(null, '*:*', function(err) {  // Clean up index
+  if (err) throw err;
+  client.commit(function(err) {
+    if (err) throw err;
+    var doc = {
+      id: 2,
+      fizzbuzz_t: {
+        params: {
+          update: 'set'
+        },
+        value: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.'
+      },
+      wakak_i: {
+        params: {
+          inc: 2
+        },
+        value: 5
+      }
+    };
+
+    console.log(doc);
+    client.add(doc, function(err, res) {
+      if (err) throw err;
+      assert.equal(solr.getStatus(res), 0, 'Add document with field parameters.');
+      client.commit(function(err, res) {
+        if (err) throw err;
+      });
+    });
+  });
+});
+


### PR DESCRIPTION
Solr supports optional parameters for documents, these optional parameters can be used for relevance query by boosting documents / fields at index time.
https://wiki.apache.org/solr/UpdateXmlMessages
